### PR TITLE
change MustCall on class to InheritableMustCall

### DIFF
--- a/src/main/java/wpi/owning/field/App.java
+++ b/src/main/java/wpi/owning/field/App.java
@@ -1,7 +1,7 @@
 package wpi.owning.field;
 
 import org.checkerframework.checker.calledmethods.qual.EnsuresCalledMethods;
-import org.checkerframework.checker.mustcall.qual.MustCall;
+import org.checkerframework.checker.mustcall.qual.InheritableMustCall;
 import java.io.IOException;
 
 class App {
@@ -18,7 +18,7 @@ class App {
         this.checkFieldsFoo.a();
     }
 
-    @MustCall("a") static class Foo {
+    @InheritableMustCall("a") static class Foo {
         void a() {}
 
         void c() {}


### PR DESCRIPTION
Required by https://github.com/typetools/checker-framework/pull/5183.

The CI build that alerted me that a change here was needed also indicates that there might be a problem with inference: inference should infer `@InheritableMustCall` on class declarations rather than `@MustCall`, if the class is non-final. @Nargeshdb, can you point me at where in the CF those annotations get inferred? `MustCallInferenceLogic` doesn't seem to have any special handling for inferring `@MustCall` annotations from `@EnsuresCalledMethods` annotations, but I was under the impression that that is how that part of the system works.