### PR TITLE
change repo to maven central; jcenter is shut down

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 repositories {
     // Use jcenter for resolving dependencies.
     // You can declare any Maven/Ivy/file repository here.
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
Ideally this ought to be going into a branch whose HEAD is at 61296ababd4467ae1e58c1f03d8f433ce4f8d695, since that's what the CF is currently using (that probably also should be the head of master?).

I think this might be the source of the flakiness @mernst has observed in the wpi-many tests.